### PR TITLE
feat: Add primary property on layer object [EP-2392]

### DIFF
--- a/packages/earth-admin/src/components/layers/layer-details/LayerDetails.tsx
+++ b/packages/earth-admin/src/components/layers/layer-details/LayerDetails.tsx
@@ -36,6 +36,7 @@ export default function LayerDetails(props: LayerProps) {
       id,
       name,
       description,
+      primary,
       published,
       version,
       createdAt,
@@ -60,6 +61,7 @@ export default function LayerDetails(props: LayerProps) {
   }, [config]);
 
   const publishIcon = published ? 'check' : 'close';
+  const primaryIcon = primary ? 'check' : 'close';
 
   function handleDeleteToggle() {
     setShowDeleteModal(!showDeleteModal);
@@ -83,6 +85,11 @@ export default function LayerDetails(props: LayerProps) {
             Published
             <br />
             <i className={`ng-icon-${publishIcon}`}></i>
+          </span>
+          <span className="ng-padding-horizontal">
+            Primary
+            <br />
+            <i className={`ng-icon-${primaryIcon}`}></i>
           </span>
         </div>
       </div>

--- a/packages/earth-admin/src/components/layers/layer-edit/LayerEdit.tsx
+++ b/packages/earth-admin/src/components/layers/layer-edit/LayerEdit.tsx
@@ -40,6 +40,7 @@ export default function LayerEdit(props: LayerProps) {
       id,
       name,
       description,
+      primary,
       published,
       version,
       createdAt,
@@ -227,6 +228,18 @@ export default function LayerEdit(props: LayerProps) {
               className="ng-margin-right"
             />
             <label htmlFor="published">Published?</label>
+          </div>
+
+          <div className="ng-margin-medium-bottom">
+            <input
+              ref={register}
+              name="primary"
+              id="primary"
+              type="checkbox"
+              defaultChecked={primary}
+              className="ng-margin-right"
+            />
+            <label htmlFor="primary">Primary?</label>
           </div>
 
           <div className="ng-width-1-1 ng-margin-large-vertical">

--- a/packages/earth-admin/src/components/layers/model.ts
+++ b/packages/earth-admin/src/components/layers/model.ts
@@ -35,6 +35,7 @@ export enum LayerProvider {
 export interface Layer {
   id: string;
   description: string;
+  primary: boolean;
   category: LayerCategory[];
   config: object;
   published: boolean;


### PR DESCRIPTION
Add "primary" property on layer model.

Allows filtering based on "primary" property to allow only parent/primary layers to be returned.