### PR TITLE
fix(admin) Remove optimistic ui updates [EP-2878]

### DIFF
--- a/packages/earth-admin/src/pages-client/dashboards/details.tsx
+++ b/packages/earth-admin/src/pages-client/dashboards/details.tsx
@@ -103,15 +103,13 @@ export function DashboardDetail(props: IProps) {
     };
 
     try {
-      // optimistic ui update
-      mutate({ ...data, ...parsed }, false);
-      setIsEditing && setIsEditing(false);
+      setIsLoading && setIsLoading(true);
       await handleDashboardForm(false, parsed, id, selectedGroup);
       mutate();
+      setIsEditing && setIsEditing(false);
+      setIsLoading && setIsLoading(false);
       onDataChange();
     } catch (error) {
-      // undo optimistic ui update
-      mutate({ ...data }, false);
       setIsLoading && setIsLoading(false);
       setServerErrors && setServerErrors(error.data.errors);
     }

--- a/packages/earth-admin/src/pages-client/layers/details.tsx
+++ b/packages/earth-admin/src/pages-client/layers/details.tsx
@@ -131,15 +131,14 @@ export function LayerDetail(props: any) {
     };
 
     try {
-      // optimistic ui update
-      mutate({ ...data, ...parsed }, false);
-      setIsEditing && setIsEditing(false);
+      setIsLoading && setIsLoading(true);
       await handleLayerForm(false, parsed, id, selectedGroup);
       mutate();
+      setIsEditing && setIsEditing(false);
+      setIsLoading && setIsLoading(false);
       onDataChange();
     } catch (error) {
-      mutate({ ...data }, false);
-      setIsLoading && setIsLoading(false); // optimistic ui update
+      setIsLoading && setIsLoading(false);
       setServerErrors && setServerErrors(error.data.errors);
     }
   }

--- a/packages/earth-admin/src/pages-client/organizations/details.tsx
+++ b/packages/earth-admin/src/pages-client/organizations/details.tsx
@@ -75,14 +75,14 @@ export function OrganizationDetails(props: OrganizationDetailsProps) {
     };
 
     try {
-      mutate({ ...data, ...parsed }, false);
-      setIsEditing(false);
+      setIsLoading && setIsLoading(true);
       await updateOrganization(id, parsed, selectedGroup);
       mutate();
+      setIsLoading && setIsLoading(false);
+      setIsEditing && setIsEditing(false);
       onDataChange();
     } catch (err) {
-      mutate({ ...data }, false);
-      setIsLoading(false);
+      setIsLoading && setIsLoading(false);
       setServerErrors(err.data.errors);
     }
   }

--- a/packages/earth-admin/src/pages-client/places/details.tsx
+++ b/packages/earth-admin/src/pages-client/places/details.tsx
@@ -127,22 +127,17 @@ export function PlaceDetail(props: IProps) {
     };
 
     try {
-      // optimistic ui update
-      mutate({ ...data, ...parsed }, false);
-
-      setIsEditing && setIsEditing(false);
+      setIsLoading && setIsLoading(true);
       await handlePlaceForm(false, parsed, id, selectedGroup);
-
       revalidate();
+      setIsEditing && setIsEditing(false);
+      setIsLoading && setIsLoading(false);
       onDataChange();
     } catch (error) {
       // TODO: Remove this when the real "upload file" feature is available.
       const fallbackError = [
         { detail: 'Something went wrong. Please make sure the selected file is under 6MB.' },
       ];
-
-      // undo optimistic ui update
-      mutate({ ...data }, false);
 
       setIsLoading && setIsLoading(false);
       setServerErrors && setServerErrors(error?.data.errors || fallbackError);


### PR DESCRIPTION
Optimistic ui updates are causing UX problems when errors are displayed. Removing them until we come up with a solution.