### PR TITLE
fix: Org switcher displays the correct selection [EP-3007]

### DIFF
--- a/packages/earth-admin/src/layouts/Sidebar.tsx
+++ b/packages/earth-admin/src/layouts/Sidebar.tsx
@@ -55,7 +55,7 @@ const SidebarLayout = (props: IProps) => {
         <AppContextSwitcher
           logo={logo}
           label={selectedGroup}
-          defaultValue={selectedGroup}
+          value={selectedGroup}
           onChange={(selectedValue) => {
             if (selectedValue === 'map-view') {
               window.location.assign(urljoin(MAP_PATH, 'earth'));

--- a/packages/earth-map/src/components/header/component.tsx
+++ b/packages/earth-map/src/components/header/component.tsx
@@ -184,7 +184,7 @@ const Header = (props: IProps) => {
     <AppContextSwitcher
       logo={logo}
       label="Map View"
-      defaultValue="map-view"
+      value="map-view"
       checkedCount={selectedGroups.length}
       renderDropdown={isAuthenticated}
       onChange={(g) => window.location.assign(`${ADMIN_URL}${g}`)}

--- a/packages/earth-shared/src/components/app-context-switcher/AppContextSwitcher.tsx
+++ b/packages/earth-shared/src/components/app-context-switcher/AppContextSwitcher.tsx
@@ -30,7 +30,7 @@ import { Option } from './Option';
 interface IProps {
   label: string;
   logo?: React.ReactNode;
-  defaultValue?: string;
+  value?: any;
   checkedCount?: number;
   renderDropdown?: boolean;
   children?: React.ReactChildren | Array<React.ReactChildren>;
@@ -41,14 +41,13 @@ const AppContextSwitcher = (props: IProps) => {
   const {
     label,
     logo,
-    defaultValue,
+    value,
     checkedCount = 0,
     renderDropdown = true,
     children,
     onChange = noop,
   } = props;
 
-  const [selectedValue, setSelectedValue] = useState(defaultValue);
   const [isOpen, setIsOpen] = useState(false);
   const toggleDropdown = () => setIsOpen(!isOpen);
   const closeDropdown = () => setIsOpen(false);
@@ -96,13 +95,12 @@ const AppContextSwitcher = (props: IProps) => {
                       return;
                     }
                     const isOptionElement = child.props.value;
-                    const selected = child.props.value === selectedValue;
+                    const selected = child.props.value === value;
                     return isOptionElement
                       ? cloneElement(child, {
                           selected,
                           onClick: (value: any) => {
                             if (!selected) {
-                              setSelectedValue(value);
                               onChange(value);
                             }
                             closeDropdown();


### PR DESCRIPTION
Because the `<AppContextSwitcher />` kept the selection in its internal state, sometimes this state could reset because of component unmount. 
Dropped the internal state and started relying on outside props