### PR TITLE
fix(auth): Configure Auth0 SDK to use local storage and rotating refr…

### DIFF
--- a/packages/earth-admin/gatsby-browser.js
+++ b/packages/earth-admin/gatsby-browser.js
@@ -31,6 +31,8 @@ export const wrapRootElement = ({ element }) => (
     onRedirectCallback={onRedirectCallback}
     onSuccessHook={onSuccessHook}
     onFailureHook={onFailureHook}
+    useRefreshTokens={true}
+    cacheLocation={'localstorage'}
   >
     {element}
   </Auth0Provider>

--- a/packages/earth-admin/package.json
+++ b/packages/earth-admin/package.json
@@ -13,7 +13,7 @@
     "typecheck": "tsc --emitDeclarationOnly"
   },
   "dependencies": {
-    "@auth0/auth0-spa-js": "^1.6.5",
+    "@auth0/auth0-spa-js": "^1.12.1",
     "@ckeditor/ckeditor5-build-classic": "^16.0.0",
     "@ckeditor/ckeditor5-react": "^2.1.0",
     "@loadable/component": "^5.10.3",

--- a/packages/earth-admin/src/auth/auth0.tsx
+++ b/packages/earth-admin/src/auth/auth0.tsx
@@ -45,7 +45,13 @@ const NAMESPACE = GATSBY_APP_AUTH0_NAMESPACE;
 export const useAuth0: any = () => useContext(Auth0Context);
 
 interface Auth0ProviderOptions {
+  domain?: any;
+  client_id?: any;
+  redirect_uri?: any;
+  audience?: any;
   children: React.ReactElement;
+  useRefreshTokens?: boolean;
+  cacheLocation?: 'memory' | 'localstorage';
   onRedirectCallback(targetUrl: string): void;
   onSuccessHook(params: any): void;
   onFailureHook(params: any): void;
@@ -149,6 +155,11 @@ export const Auth0Provider = ({
     initAuth0();
   }, []); // eslint-disable-line
 
+  /**
+   * Logging-in will automatically request the offline_access scope and store the resulting
+   * refresh token.
+   * @param options
+   */
   const login = useCallback(
     (options = {}) => {
       return client.loginWithRedirect && client.loginWithRedirect(options);
@@ -164,16 +175,21 @@ export const Auth0Provider = ({
     [client]
   );
 
-  const getUser = useCallback(
-    (options: GetUserOptions = {} as any) => {
-      return client.getUser && client.getUser(options);
+  /**
+   * Silently refreshing the access token will use the /token endpoint with ‘refresh_token’
+   * grant and the refresh token from the cache.
+   * @param options
+   */
+  const getToken = useCallback(
+    (options: GetTokenSilentlyOptions = {} as any) => {
+      return client.getTokenSilently && client.getTokenSilently(options);
     },
     [client]
   );
 
-  const getToken = useCallback(
-    (options: GetTokenSilentlyOptions = {} as any) => {
-      return client.getTokenSilently && client.getTokenSilently(options);
+  const getUser = useCallback(
+    (options: GetUserOptions = {} as any) => {
+      return client.getUser && client.getUser(options);
     },
     [client]
   );

--- a/packages/earth-admin/src/utils/hooks.tsx
+++ b/packages/earth-admin/src/utils/hooks.tsx
@@ -122,7 +122,7 @@ export function useInfiniteListPaged(
 }
 
 interface IMergedResults {
-  data: Array<any>;
+  data: any[];
   pagination?: {
     size: number;
     total: number;
@@ -134,7 +134,7 @@ interface IMergedResults {
 /**
  * Merge multiple page results into a single list of results
  */
-export function mergePages(pagedResponse: Array<any>): IMergedResults {
+export function mergePages(pagedResponse: any[]): IMergedResults {
   return pagedResponse.reduce(
     (acc: any, { data, ...rest }: any) => {
       return {

--- a/packages/earth-map/package.json
+++ b/packages/earth-map/package.json
@@ -10,7 +10,7 @@
     "typecheck": "tsc --emitDeclarationOnly"
   },
   "dependencies": {
-    "@auth0/auth0-spa-js": "^1.6.5",
+    "@auth0/auth0-spa-js": "^1.12.1",
     "@fullpage/react-fullpage": "^0.1.14",
     "@marapp/earth-shared": "*",
     "@researchgate/react-intersection-list": "^3.0.10",

--- a/packages/earth-map/src/auth/auth0.tsx
+++ b/packages/earth-map/src/auth/auth0.tsx
@@ -42,6 +42,8 @@ interface Auth0ProviderOptions {
   redirect_uri?: any;
   audience?: any;
   children: React.ReactElement;
+  useRefreshTokens?: boolean;
+  cacheLocation?: 'memory' | 'localstorage';
   onRedirectCallback(targetUrl: any): void;
   onSuccessHook(params: any): void;
   onFailureHook(params: any): void;
@@ -140,6 +142,11 @@ export const Auth0Provider = ({
     initAuth0();
   }, []); // eslint-disable-line
 
+  /**
+   * Logging-in will automatically request the offline_access scope and store the resulting
+   * refresh token.
+   * @param options
+   */
   const login = (options = {}) => {
     SessionStorage.remove('ephemeral');
     return client.loginWithRedirect(options);
@@ -151,12 +158,17 @@ export const Auth0Provider = ({
     return client.logout({ ...options, federated: true });
   };
 
-  const getUser = (options = {}) => {
-    return client.getUser(options);
-  };
-
+  /**
+   * Silently refreshing the access token will use the /token endpoint with ‘refresh_token’
+   * grant and the refresh token from the cache.
+   * @param options
+   */
   const getToken = (options = {}) => {
     return client.getTokenSilently(options);
+  };
+
+  const getUser = (options = {}) => {
+    return client.getUser(options);
   };
 
   return (

--- a/packages/earth-map/src/index.tsx
+++ b/packages/earth-map/src/index.tsx
@@ -45,6 +45,8 @@ ReactDOM.render(
     onRedirectCallback={onRedirectCallback}
     onSuccessHook={onSuccessHook}
     onFailureHook={onFailureHook}
+    useRefreshTokens={true}
+    cacheLocation={'localstorage'}
   >
     <App />
   </Auth0Provider>,

--- a/yarn.lock
+++ b/yarn.lock
@@ -15,16 +15,16 @@
   resolved "https://registry.yarnpkg.com/@ardatan/aggregate-error/-/aggregate-error-0.0.1.tgz#1403ac5de10d8ca689fc1f65844c27179ae1d44f"
   integrity sha512-UQ9BequOTIavs0pTHLMwQwKQF8tTV1oezY/H2O9chA+JNPFZSua55xpU5dPSjAU9/jLJ1VwU+HJuTVN8u7S6Fg==
 
-"@auth0/auth0-spa-js@^1.6.5":
-  version "1.11.0"
-  resolved "https://registry.yarnpkg.com/@auth0/auth0-spa-js/-/auth0-spa-js-1.11.0.tgz#800a59ddeaa11ad8a94a699c58f9971842ea065f"
-  integrity sha512-PHYykO4IoEGeTT2SVzvZiJNK5QgznLJweJfVcb0C8X+rZYooBN5Qrdj0AfECzgK9h90kfU4u3s9h83VTSh6t3A==
+"@auth0/auth0-spa-js@^1.12.1":
+  version "1.12.1"
+  resolved "https://registry.yarnpkg.com/@auth0/auth0-spa-js/-/auth0-spa-js-1.12.1.tgz#791cdda722afa25f4c8879b93b8d7ab54a26e4c1"
+  integrity sha512-YdXtA1T2wK4iNG79VlGS/CPfNNezS1nqZURerj71jKSf8ICVKmvJgUNXFEZEwNNU/KFdCCPCHd5wMeWLDyEILw==
   dependencies:
-    abortcontroller-polyfill "^1.4.0"
-    browser-tabs-lock "^1.2.8"
-    core-js "^3.6.4"
+    abortcontroller-polyfill "^1.5.0"
+    browser-tabs-lock "^1.2.9"
+    core-js "^3.6.5"
     es-cookie "^1.3.2"
-    fast-text-encoding "^1.0.1"
+    fast-text-encoding "^1.0.3"
     promise-polyfill "^8.1.3"
     unfetch "^4.1.0"
 
@@ -4506,7 +4506,7 @@ abbrev@1, abbrev@~1.1.1:
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.1.tgz#f8f2c887ad10bf67f634f005b6987fed3179aac8"
   integrity sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==
 
-abortcontroller-polyfill@^1.4.0:
+abortcontroller-polyfill@^1.5.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/abortcontroller-polyfill/-/abortcontroller-polyfill-1.5.0.tgz#2c562f530869abbcf88d949a2b60d1d402e87a7c"
   integrity sha512-O6Xk757Jb4o0LMzMOMdWvxpHWrQzruYBaUruFaIOfAQRnWFxfdXYobw12jrVHGtoXk6WiiyYzc0QWN9aL62HQA==
@@ -5903,7 +5903,7 @@ browser-resolve@^1.11.3:
   dependencies:
     resolve "1.1.7"
 
-browser-tabs-lock@^1.2.8:
+browser-tabs-lock@^1.2.9:
   version "1.2.11"
   resolved "https://registry.yarnpkg.com/browser-tabs-lock/-/browser-tabs-lock-1.2.11.tgz#59d72c6653b827685b54fca1c0e6eb4aee08ef52"
   integrity sha512-R0xXMzQ8CU0v52zSFn3EDGIfsjteMFJ6oIhhZK6+Vhz5NYzSxCP2epLD9PN7e2HprQl2QTReFptwp6c9tdOF0g==
@@ -7344,7 +7344,7 @@ core-js@^2.4.0, core-js@^2.5.7, core-js@^2.6.10, core-js@^2.6.5:
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.11.tgz#38831469f9922bded8ee21c9dc46985e0399308c"
   integrity sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg==
 
-core-js@^3.5.0, core-js@^3.6.4, core-js@^3.6.5:
+core-js@^3.5.0, core-js@^3.6.5:
   version "3.6.5"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.6.5.tgz#7395dc273af37fb2e50e9bd3d9fe841285231d1a"
   integrity sha512-vZVEEwZoIsI+vPEuoF9Iqf5H7/M3eeQqWlQnYa8FSKKePuYTf5MWnxb5SDAzCa60b3JBRS5g9b+Dq7b1y/RCrA==
@@ -9899,7 +9899,7 @@ fast-safe-stringify@^2.0.4:
   resolved "https://registry.yarnpkg.com/fast-safe-stringify/-/fast-safe-stringify-2.0.7.tgz#124aa885899261f68aedb42a7c080de9da608743"
   integrity sha512-Utm6CdzT+6xsDk2m8S6uL8VHxNwI6Jub+e9NYTcAms28T84pTa25GJQV9j0CY0N1rM8hK4x6grpF2BQf+2qwVA==
 
-fast-text-encoding@^1.0.1:
+fast-text-encoding@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/fast-text-encoding/-/fast-text-encoding-1.0.3.tgz#ec02ac8e01ab8a319af182dae2681213cfe9ce53"
   integrity sha512-dtm4QZH9nZtcDt8qJiOH9fcQd1NAgi+K1O2DbE6GG1PPCK/BWfOH3idCTRQ4ImXRUOyopDEgDEnVEE7Y/2Wrig==


### PR DESCRIPTION
CHANGES:
- Configure Auth0 SDK to use the new Rotating Refresh Token on the client side.
- Use `localstorage` for cache location instead of memory, to avoid blocking third-party cookies. 

```
Auth0 has built-in reuse detection - if a refresh token is leaked and used, a subsequent exchange 
will kick in the detection and the entire “family” of refresh tokens will be invalidated. 
(With the Rotating Refresh token approach, it’s okay to store the refresh and access tokens in local storage)
```

(source: https://auth0.com/docs/tokens/refresh-tokens/refresh-token-rotation/use-refresh-token-rotation#example)