### PR TITLE
fix(admin): Error is still displayed, even after correct value was sa…

### DIFF
--- a/packages/earth-admin/src/pages-client/layers/details.tsx
+++ b/packages/earth-admin/src/pages-client/layers/details.tsx
@@ -31,6 +31,7 @@ import {
   ErrorMessages,
   InlineEditCard,
   Input,
+  notEmptyRule,
   setupErrors,
 } from '@marapp/earth-shared';
 
@@ -283,7 +284,12 @@ export function LayerDetail(props: any) {
                             ...theme,
                             ...SELECT_THEME,
                           })}
-                          rules={{ required: true }}
+                          rules={{
+                            required: true,
+                            validate: {
+                              notEmptyRule: notEmptyRule('Layer category cannot be empty'),
+                            },
+                          }}
                         />
                         <div className="ng-form-error-block">
                           <ErrorMessage

--- a/packages/earth-shared/src/validations.ts
+++ b/packages/earth-shared/src/validations.ts
@@ -72,6 +72,8 @@ const alphaNumericDashes = (value: string): boolean => {
   return regex.test(value);
 };
 
+const notEmpty = (value: []): boolean => value.length > 0;
+
 /**
  * Validation rules used by react-hook-form
  * Allow for message customization
@@ -104,6 +106,9 @@ export const valueChangedRule = (
   previousValue,
   errorMessage: string = 'Please enter a different email'
 ) => compose(maybeShowError(errorMessage), valueChanged)(value, previousValue);
+
+export const notEmptyRule = (errorMessage: string = 'Cannot be empty') =>
+  compose(maybeShowError(errorMessage), notEmpty);
 
 export const setupErrors = (errors, touched) => (field: string): string => {
   const fieldErr: any = errors[field];


### PR DESCRIPTION
…ved [EP-3021]

By submitting a PR to this repository, you agree to the terms within the [Code of Conduct](https://github.com/natgeosociety/marapp-frontend/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/natgeosociety/marapp-frontend/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

> Describe the purpose of this PR along with any background information and the impacts of the proposed change. For the benefit of the community, please do not assume prior context.
>
> Provide details that support your chosen implementation, including: breaking changes, alternatives considered, changes to the API, etc.


### References

> Include any links supporting this change such as a:
>
> - GitHub Issue/PR number addressed or fixed
> - StackOverflow post
> - Support forum thread
> - Related pull requests/issues from other repos
>
> If there are no references, simply delete this section.

### Testing

> Describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.
>
> Please include any manual steps for testing end-to-end or functionality not covered by unit/integration tests.
>
> Also include details of the environment this PR was developed in (language/platform/browser version).

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in /docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `master`

[EP-3021]: https://nationalgeographicatlassianprod.atlassian.net/browse/EP-3021